### PR TITLE
Enable configurable PWM frequency

### DIFF
--- a/aero_compute_board/src/pwm.v
+++ b/aero_compute_board/src/pwm.v
@@ -6,13 +6,13 @@
 // without limitation, warranties of merchantability, non-infringement, or  
 // fitness for a particular purpose, are specifically disclaimed.
 //
-//
+// Authors: Rich West and Zhuoqun Cheng @ Boston University
 // ----------------------------------------------------------------------------
 
 
 
 module pwm (
-       input clk,
+     input clk,
 		 input resetn,
 		 output pwm,
 		 input pwm_on,
@@ -21,71 +21,40 @@ module pwm (
 		 input [7:0]pwmDutyh,
 		 input [7:0]pwmFreql,
 		 input [7:0]pwmFreqh
-		);
+);
 		
-		
-reg [15:0]pwmDutyReg;
-reg [15:0]pwmFreqReg;
-reg pwmClk;
 wire [15:0]pwmFreqR;
 wire [15:0]pwmDutyR;
 
-reg [1:0]pwmClkBuf;
-reg pwm_r;
-
+reg pwm_d, pwm_r;
+reg [15:0] ctr, ramp;
+reg [31:0] pwmScale;
+  
 assign pwm = pwm_r;
-
-
 assign pwmDutyR = {pwmDutyh,pwmDutyl};
-assign pwmFreqR = {pwmFreqh,pwmFreql};
-
-
-always @(posedge clk or negedge resetn) begin
-   if(~resetn)  begin
-      pwmFreqReg <= 16'h0000;
-      pwmClk <= 0;
-   end	
-   else if ((pwmFreqReg > pwmFreqR) || ~pwm_on || ~pwm_enb) begin
-      pwmFreqReg <= 16'h0000;
-      pwmClk <= 0;
-   end 
-	else if (pwmFreqReg == pwmFreqR)begin
-      pwmClk <= ~pwmClk;
-      pwmFreqReg <= 16'h0000;
-   end 
-	else
-      pwmFreqReg <= pwmFreqReg + 16'h0001;
-end
-
-
-always @(posedge clk) begin
- 
-	pwmClkBuf[1:0] <= {pwmClkBuf[0],pwmClk}; // test
-	
-end
-
-always @(posedge clk  or negedge resetn) begin
-  if (~resetn)
-     pwmDutyReg <= 16'h0000;     
-  else if ((pwmDutyR == 0) || ~pwm_on || ~pwm_enb) 
-     pwmDutyReg <= 16'h0000;
-  else if( ~pwmClkBuf[1] && pwmClkBuf[0])     //clock rising edge
-     pwmDutyReg <= pwmDutyReg + 16'h0000;
-  else 
-     pwmDutyReg <= pwmDutyReg + 16'h0001;
+assign pwmFreqR = {pwmFreqh,pwmFreql};  
+   
+always @(*) begin
+   ctr = ramp + 1'b1;
+   
+	if (ctr >= pwmFreqR)
+	  ctr = 16'h0000; 
      
+	pwmScale = pwmDutyR * pwmFreqR;
+   if (pwmScale >>> 16 > ramp)
+     pwm_d = 1'b1;
+   else
+     pwm_d = 1'b0;
 end
-
-
+   
 always @(posedge clk) begin
-   if (pwmDutyReg >= pwmDutyR)
-      pwm_r <= 0;
-   else if(pwmDutyReg == 0)
-      pwm_r <= 0;
-	else 
-	   pwm_r <= 1;
+   if ((~resetn) || (ramp >= pwmFreqR))
+     ramp <= 16'h0000;
+   else
+     ramp <= ctr;
+    
+   pwm_r <= pwm_d;
 end
 
-endmodule   
-		
-                             
+endmodule
+


### PR DESCRIPTION
The origial implementation of PWM has a fixed frequency at (25M/2^16) Hz.
This commit enables configurable PWM frequency, via SPI commands.