### PR TITLE
aero-rtf: Increase version

### DIFF
--- a/aero_rtf_kit/RTL/top.v
+++ b/aero_rtf_kit/RTL/top.v
@@ -69,7 +69,7 @@ module Top (
         BOOTLOADER_FORCE_PIN
 );
 
-parameter fpga_ver = 8'hC1;
+parameter fpga_ver = 8'hC2;
 
 // global
 input wire in_CLK;


### PR DESCRIPTION
Commits since last version:
aero_rtf_kit: Allow to set force bootloader pin in runtime
aero_rtf_kit: improve table documentation
aero-rtf: Fix SPI transaction
aero-rtf: Use the 50MHz clock in SPI slave
aero-rtf: Reuse the slave select falling edge detection
aero-rtf: Add I2C slave module
aero-rtf: Reimplement ADC and move to his own module
aero-rtf: group I2C bridges and use 4 spaces to indent
aero-rtf: make adc backward compatible
aero-rtf: adc: Guarantee synchronism of lower and upper bytes of sample